### PR TITLE
Fix broken Table

### DIFF
--- a/cocksmithing.md
+++ b/cocksmithing.md
@@ -415,7 +415,6 @@ For convenience, here's a compact list of products used. Links in the leftmost c
 |   |                                                                                    |                               |                        |                                                                               |
 |   | **Consumables**                                                                    |                               |                        |                                                                               |
 |   | 1oz Mixing Container                                                               |         XTC-3D mixing         |           10           |                                     $5.00                                     |
-
 |   | 16oz Mixing Container                                                              |        Silicone Mixing        |           10           |         [$6.31](https://www.reynoldsam.com/product/mixing-containers/)        |
 |   | 32oz Mixing Container                                                              |        Silicone Mixing        |           10           |         [$7.60](https://www.reynoldsam.com/product/mixing-containers/)        |
 |   | 64oz Mixing Container                                                              | Silicone Mixing (larger toys) |           10           |        [$18.94](https://www.reynoldsam.com/product/mixing-containers/)        |


### PR DESCRIPTION
The table in the guide is busted part way through by the addition of an errant blank line; this is a simple one newline deletion to fix this.